### PR TITLE
Add aggregate strategy for Employee-Department association

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4.4.1
+
+    - name: Check code formatting
+      run: ./gradlew spotlessCheck
+
+    - name: Build with generated files
+      run: ./gradlew clean generateAll build
+    
+    - name: Run application
+      run: ./gradlew run
+    
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results
+        path: build/test-results/test/
+    
+    - name: Upload build reports
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: build-reports
+        path: build/reports/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,10 @@ application {
     mainClass.set("com.example.Main")
 }
 
+var daoPackagePath = "src/main/java/com/example/dao"
+var entityPackagePath = "src/main/java/com/example/entity"
+var sqlFileDirPath = "src/main/resources/META-INF/com/example/dao"
+
 tasks {
     test {
         useJUnitPlatform()
@@ -47,10 +51,6 @@ tasks {
     register("generateAll") {
         dependsOn("generateDAOs", "generateEntities", "generateSqlFiles")
     }
-
-    var daoPackagePath = "src/main/java/com/example/dao"
-    var entityPackagePath = "src/main/java/com/example/entity"
-    var sqlFileDirPath = "src/main/resources/META-INF/com/example/dao"
 
     register("generateDAOs") {
         dependsOn("generateEntities")
@@ -262,7 +262,7 @@ spotless {
     java {
         googleJavaFormat(libs.versions.googleJavaFormat.get())
         target("src/*/java/**/*.java")
-        targetExclude("**/generated/**")
+        targetExclude("**/generated/**", "$daoPackagePath/**", "$entityPackagePath/**", "$sqlFileDirPath/**")
     }
     kotlin {
         target("*.gradle.kts")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ tasks {
                            INNER JOIN department$i d
                                    ON e.department_id = d.id
                      WHERE e.id = /*id*/0 
-                """.trimIndent()
+                    """.trimIndent(),
                 )
             }
             println("Generated SQL files in src/main/resources/META-INF/com/example/dao/EmployeeXxxDao")
@@ -158,11 +158,11 @@ fun writeEmployeeAggregateStrategyCode(
         import com.example.entity.Department$i;
         import com.example.entity.Employee$i;
         
-        @AggregateStrategy(root = Employee${i}.class, tableAlias = "e")
+        @AggregateStrategy(root = Employee$i.class, tableAlias = "e")
         public interface Employee${i}AggregateStrategy {
         
           @AssociationLinker(propertyPath = "department", tableAlias = "d")
-          BiConsumer<Employee${i}, Department${i}> department =
+          BiConsumer<Employee$i, Department$i> department =
               (e, d) -> {
                 e.department = d;
                 d.employees.add(e);

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,8 @@ tasks {
             (1..generationSize).forEach { i ->
                 val employeeDaoFile = File(sourceDir, "Employee${i}Dao.java")
                 writeEmployeeDaoCode(employeeDaoFile, i)
+                val employeeAggregateStrategyFile = File(sourceDir, "Employee${i}AggregateStrategy.java")
+                writeEmployeeAggregateStrategyCode(employeeAggregateStrategyFile, i)
             }
             println("Generated DAO files in src/main/java/com/example/dao")
         }
@@ -87,7 +89,15 @@ tasks {
                 dir.mkdirs()
 
                 val sqlFile = File(dir, "selectById.sql")
-                sqlFile.writeText("select /*%expand*/* from employee$i where id = /*id*/0\n")
+                sqlFile.writeText(
+                    """
+                    SELECT /*%expand*/*
+                      FROM employee$i e
+                           INNER JOIN department$i d
+                                   ON e.department_id = d.id
+                     WHERE e.id = /*id*/0 
+                """.trimIndent()
+                )
             }
             println("Generated SQL files in src/main/resources/META-INF/com/example/dao/EmployeeXxxDao")
         }
@@ -125,8 +135,38 @@ fun writeEmployeeDaoCode(
             @Delete
             int delete(Employee$i entity);
             
-            @Select
+            @Select(aggregateStrategy = Employee${i}AggregateStrategy.class)
             Employee$i selectById(Long id);
+        }
+        """.trimIndent(),
+    )
+}
+
+fun writeEmployeeAggregateStrategyCode(
+    file: File,
+    i: Int,
+) {
+    file.writeText(
+        """
+        package com.example.dao;
+        
+        import org.seasar.doma.AggregateStrategy;
+        import org.seasar.doma.AssociationLinker;
+        
+        import java.util.function.BiConsumer;
+        
+        import com.example.entity.Department$i;
+        import com.example.entity.Employee$i;
+        
+        @AggregateStrategy(root = Employee${i}.class, tableAlias = "e")
+        public interface Employee${i}AggregateStrategy {
+        
+          @AssociationLinker(propertyPath = "department", tableAlias = "d")
+          BiConsumer<Employee${i}, Department${i}> department =
+              (e, d) -> {
+                e.department = d;
+                d.employees.add(e);
+              };
         }
         """.trimIndent(),
     )
@@ -191,6 +231,7 @@ fun writeDepartmentCode(
         """
         package com.example.entity;
         
+        import java.util.ArrayList;
         import java.util.List;
         
         import org.seasar.doma.Association;
@@ -211,7 +252,7 @@ fun writeDepartmentCode(
             @Version
             public Integer version;
             @Association
-            public List<Employee$i> employees;
+            public List<Employee$i> employees = new ArrayList<>();
         }
         """.trimIndent(),
     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 junit = "5.10.0"
-doma = "3.9.1-SNAPSHOT"
+doma = "3.9.0"
 h2 = "2.3.232"
 slf4j = "2.0.17"
 logback = "1.5.18"

--- a/src/main/java/com/example/Department.java
+++ b/src/main/java/com/example/Department.java
@@ -1,6 +1,8 @@
 package com.example;
 
 import com.example.domain.Name;
+
+import java.util.ArrayList;
 import java.util.List;
 import org.seasar.doma.Association;
 import org.seasar.doma.Entity;
@@ -18,5 +20,5 @@ public class Department {
 
   public Name name;
   @Version public Integer version;
-  @Association public List<Employee> employees;
+  @Association public List<Employee> employees = new ArrayList<>();
 }

--- a/src/main/java/com/example/Department.java
+++ b/src/main/java/com/example/Department.java
@@ -1,7 +1,6 @@
 package com.example;
 
 import com.example.domain.Name;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.seasar.doma.Association;

--- a/src/main/java/com/example/EmployeeAggregateStrategy.java
+++ b/src/main/java/com/example/EmployeeAggregateStrategy.java
@@ -1,0 +1,17 @@
+package com.example;
+
+import org.seasar.doma.AggregateStrategy;
+import org.seasar.doma.AssociationLinker;
+
+import java.util.function.BiConsumer;
+
+@AggregateStrategy(root = Employee.class, tableAlias = "e")
+public interface EmployeeAggregateStrategy {
+
+  @AssociationLinker(propertyPath = "department", tableAlias = "d")
+  BiConsumer<Employee, Department> department =
+      (e, d) -> {
+        e.department = d;
+        d.employees.add(e);
+      };
+}

--- a/src/main/java/com/example/EmployeeAggregateStrategy.java
+++ b/src/main/java/com/example/EmployeeAggregateStrategy.java
@@ -1,9 +1,8 @@
 package com.example;
 
+import java.util.function.BiConsumer;
 import org.seasar.doma.AggregateStrategy;
 import org.seasar.doma.AssociationLinker;
-
-import java.util.function.BiConsumer;
 
 @AggregateStrategy(root = Employee.class, tableAlias = "e")
 public interface EmployeeAggregateStrategy {

--- a/src/main/java/com/example/EmployeeDao.java
+++ b/src/main/java/com/example/EmployeeDao.java
@@ -18,7 +18,7 @@ public interface EmployeeDao {
   @Delete
   int delete(Employee entity);
 
-  @Select
+  @Select(aggregateStrategy = EmployeeAggregateStrategy.class)
   Employee selectById(Long id);
 
   @Script

--- a/src/main/java/com/example/Main.java
+++ b/src/main/java/com/example/Main.java
@@ -6,6 +6,8 @@ import org.seasar.doma.slf4j.Slf4jJdbcLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 public class Main {
 
   private static final Logger logger = LoggerFactory.getLogger(Main.class);
@@ -16,10 +18,15 @@ public class Main {
             .naming(Naming.SNAKE_LOWER_CASE)
             .jdbcLogger(new Slf4jJdbcLogger())
             .build();
-    var employeeDao = new EmployeeDaoImpl(config);
+    EmployeeDao employeeDao = new EmployeeDaoImpl(config);
     employeeDao.create();
     var employee = employeeDao.selectById(1L);
 
+    Objects.requireNonNull(employee);
+    Objects.requireNonNull(employee.name);
+    Objects.requireNonNull(employee.department);
+
     logger.info(employee.name.value()); // John Smith
+    logger.info(employee.department.name.value()); // Engineering
   }
 }

--- a/src/main/java/com/example/Main.java
+++ b/src/main/java/com/example/Main.java
@@ -1,12 +1,11 @@
 package com.example;
 
+import java.util.Objects;
 import org.seasar.doma.jdbc.Naming;
 import org.seasar.doma.jdbc.SimpleConfig;
 import org.seasar.doma.slf4j.Slf4jJdbcLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Objects;
 
 public class Main {
 

--- a/src/main/resources/META-INF/com/example/EmployeeDao/selectById.sql
+++ b/src/main/resources/META-INF/com/example/EmployeeDao/selectById.sql
@@ -1,1 +1,5 @@
-select /*%expand*/* from employee where id = /*id*/0
+SELECT /*%expand*/*
+  FROM employee e
+       INNER JOIN department d
+               ON e.department_id = d.id
+ WHERE e.id = /*id*/0 


### PR DESCRIPTION
## Summary
- Implement aggregate strategy pattern to automatically map Department entities when selecting Employees
- Add EmployeeAggregateStrategy with association linker for bidirectional mapping
- Update build script to generate aggregate strategy classes for all generated DAOs

## Changes
- Created `EmployeeAggregateStrategy` interface with `@AggregateStrategy` and `@AssociationLinker` annotations
- Updated `EmployeeDao.selectById()` to use the aggregate strategy
- Modified SQL queries to include JOIN with department table
- Initialize `employees` list in Department entities to avoid null pointer exceptions
- Extended build script to generate aggregate strategy classes for all Employee DAOs

## Test plan
- [x] Run `./gradlew clean build` to ensure compilation succeeds
- [x] Run `./gradlew run` to verify the Main class executes correctly
- [x] Run `./gradlew generateAll` to generate all DAOs with aggregate strategies
- [x] Verify that Employee entities now have their Department association populated

🤖 Generated with [Claude Code](https://claude.ai/code)