### PR TITLE
Enable Gradle build caching and parallel test execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,9 @@ spotless {
 tasks {
     test {
         useJUnitPlatform()
+        systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+        systemProperty("junit.jupiter.execution.parallel.mode.default", "same_thread")
+        systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
     }
 
     compileJava {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.caching=true
+org.gradle.jvmargs=-Xmx2048M


### PR DESCRIPTION
## Summary
- Add gradle.properties file to enable Gradle build caching
- Configure JUnit 5 parallel test execution for faster test runs
- Set JVM max memory to 2048M for better build performance

## Test plan
- [x] Run `./gradlew clean build` to verify build works correctly
- [x] Run `./gradlew test` to ensure tests pass with parallel execution
- [x] Verify build caching is working by running build twice and checking second run is faster

🤖 Generated with [Claude Code](https://claude.ai/code)